### PR TITLE
Prevent horizontal scrolling by clipping content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,6 +4,8 @@
 }
 html{
     scroll-behavior: smooth;
+    max-width: 100%;
+    overflow-x: hidden;
 }
 nav{
     font-family: 'Source Sans Pro', sans-serif;


### PR DESCRIPTION
- Add a max width to the page of 100%
- Clip horizontal content with `overflow-x: hidden`